### PR TITLE
Add initial Flask app and modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,16 @@
+from flask import Flask, render_template, jsonify
+from bluetooth_scan import scan_devices
+
+app = Flask(__name__)
+
+@app.route('/')
+def dashboard():
+    return render_template('partials/dashboard.html')
+
+@app.route('/live')
+def live():
+    devices = scan_devices()
+    return jsonify(devices)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/bluetooth_scan.py
+++ b/bluetooth_scan.py
@@ -1,0 +1,10 @@
+import bluetooth
+
+
+def scan_devices():
+    """Scan for nearby Bluetooth devices."""
+    try:
+        devices = bluetooth.discover_devices(duration=8, lookup_names=True)
+        return [{'address': addr, 'name': name} for addr, name in devices]
+    except bluetooth.BluetoothError:
+        return []

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "telegram": {
+    "api_token": "YOUR_API_TOKEN",
+    "chat_id": "YOUR_CHAT_ID"
+  }
+}

--- a/gpt_integration.py
+++ b/gpt_integration.py
@@ -1,0 +1,7 @@
+"""Placeholder for GPT log analysis."""
+
+
+def analyze_logs(log_text: str) -> str:
+    """Analyze logs using a GPT model (not implemented)."""
+    # This is a stub for future GPT integration.
+    return "Analysis not implemented"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+pybluez
+pyserial
+pynmea2
+requests

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,7 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+}
+nav a {
+    margin-right: 1em;
+}

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -1,0 +1,1 @@
+// Placeholder file for chart functions

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,21 @@
+// Simple fetch for live scan results
+function loadLive() {
+  fetch('/live')
+    .then(resp => resp.json())
+    .then(data => {
+      const list = document.getElementById('device-list');
+      if (!list) return;
+      list.innerHTML = '';
+      data.forEach(dev => {
+        const li = document.createElement('li');
+        li.textContent = dev.address + ' - ' + dev.name;
+        list.appendChild(li);
+      });
+    });
+}
+
+// Auto-refresh live view
+if (document.getElementById('device-list')) {
+  setInterval(loadLive, 5000);
+  loadLive();
+}

--- a/telegram_integration.py
+++ b/telegram_integration.py
@@ -1,0 +1,30 @@
+"""Simple Telegram API helper functions."""
+
+import json
+import requests
+
+CONFIG_FILE = 'config.json'
+
+
+def _load_config():
+    try:
+        with open(CONFIG_FILE, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def send_message(text: str) -> None:
+    """Send a text message via Telegram if configured."""
+    cfg = _load_config().get('telegram', {})
+    token = cfg.get('api_token')
+    chat_id = cfg.get('chat_id')
+    if not token or not chat_id:
+        return
+    url = f'https://api.telegram.org/bot{token}/sendMessage'
+    payload = {'chat_id': chat_id, 'text': text}
+    try:
+        requests.post(url, data=payload, timeout=10)
+    except requests.RequestException:
+        # Ignore network errors for now
+        pass

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BT Scan Tool</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body>
+<nav>
+    <a href="/">Dashboard</a>
+    <a href="/live">Live</a>
+</nav>
+<div id="content">
+    {% block content %}{% endblock %}
+</div>
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
+</body>
+</html>

--- a/templates/partials/dashboard.html
+++ b/templates/partials/dashboard.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Dashboard</h2>
+<p>Welcome to the BT Scan Tool.</p>
+{% endblock %}

--- a/templates/partials/live.html
+++ b/templates/partials/live.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Live Devices</h2>
+<ul id="device-list"></ul>
+{% endblock %}

--- a/templates/partials/logs.html
+++ b/templates/partials/logs.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Logs</h2>
+<pre id="log-content">Log file not loaded.</pre>
+{% endblock %}

--- a/templates/partials/map.html
+++ b/templates/partials/map.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Map</h2>
+<p>Map view not implemented.</p>
+{% endblock %}

--- a/templates/partials/settings.html
+++ b/templates/partials/settings.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Settings</h2>
+<p>Configure API tokens in config.json.</p>
+{% endblock %}

--- a/templates/partials/stats.html
+++ b/templates/partials/stats.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Statistics</h2>
+<p>Charts will appear here.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide base Flask app with Bluetooth scanning
- add GPT and Telegram integration stubs
- add HTML templates and static assets
- include sample config file and log placeholder
- document dependencies in `requirements.txt`

## Testing
- `python3 -m compileall .`

------
https://chatgpt.com/codex/tasks/task_e_6859afffc6d88331b3de1dc69218039a